### PR TITLE
Feat/#21/하은이의 분노

### DIFF
--- a/src/controllers/stdController.js
+++ b/src/controllers/stdController.js
@@ -48,4 +48,20 @@ export const stdController = {
             next(error);
         }
     },
+
+    async angerReset(req, res, next) {
+        try {
+            const { targetTeamId } = req.body;
+            const user = req.user;
+
+            if (!targetTeamId) {
+                return res.status(400).json({ message: '대상 팀 ID가 필요합니다.' });
+            }
+
+            const result = await stdService.angerReset(user, targetTeamId);
+            res.json(result);
+        } catch (error) {
+            next(error);
+        }
+    },
 };

--- a/src/models/teamModel.js
+++ b/src/models/teamModel.js
@@ -217,6 +217,36 @@ export const teamModel = {
     return stmt.run(newFlags, teamId);
   },
 
+  // === ANGER 권한 관리 ===
+  grantAngerPermission(teamId) {
+    const db = getDatabase();
+    const team = this.findById(teamId);
+    const newFlags = grantPermission(team.permission_flags || 0, PERMISSION.ANGER);
+    const stmt = db.prepare('UPDATE teams SET permission_flags = ? WHERE id = ?');
+    return stmt.run(newFlags, teamId);
+  },
+
+  hasAngerPermission(teamId) {
+    const db = getDatabase();
+    const stmt = db.prepare('SELECT permission_flags FROM teams WHERE id = ?');
+    const result = stmt.get(teamId);
+    return result && hasPermission(result.permission_flags || 0, PERMISSION.ANGER);
+  },
+
+  revokeAngerPermission(teamId) {
+    const db = getDatabase();
+    const team = this.findById(teamId);
+    const newFlags = revokePermission(team.permission_flags || 0, PERMISSION.ANGER);
+    const stmt = db.prepare('UPDATE teams SET permission_flags = ? WHERE id = ?');
+    return stmt.run(newFlags, teamId);
+  },
+
+  resetTeamCredit(teamId) {
+    const db = getDatabase();
+    const stmt = db.prepare('UPDATE teams SET team_credit = 3000 WHERE id = ?');
+    return stmt.run(teamId);
+  },
+
   stealCredit(stealerTeamId, victimTeamId, stealPercent) {
     const db = getDatabase();
     const transaction = db.transaction(() => {

--- a/src/routes/std.js
+++ b/src/routes/std.js
@@ -7,5 +7,6 @@ const router = express.Router();
 router.post('/select/pull', authenticateToken, requireStudent, stdController.pullCard);
 router.post('/select/pull/shuffle', authenticateToken, requireStudent, stdController.swapCredit);
 router.post('/select/pull/steal', authenticateToken, requireStudent, stdController.stealCredit);
+router.post('/select/pull/anger', authenticateToken, requireStudent, stdController.angerReset);
 
 export default router;

--- a/src/services/stdService.js
+++ b/src/services/stdService.js
@@ -143,6 +143,7 @@ export const stdService = {
 
             case 'anger':
                 // 하은이의 분노 - 프론트엔드에서 팀 선택 필요
+                teamModel.grantAngerPermission(teamId); // 권한 부여
                 message = '하은이의 분노!!!!!!!!!';
                 effect = 'anger';
                 return { message, effect };
@@ -287,6 +288,55 @@ export const stdService = {
             },
             stolenAmount: result.stolenAmount,
             stealPercent
+        };
+    },
+
+    async angerReset(user, targetTeamId) {
+        // 1. 입력 유효성 검사
+        if (!targetTeamId || typeof targetTeamId !== 'number') {
+            throw { status: 400, message: 'ID가 잘못되었습니다', code: 'INCORRECT_TEAM' };
+        }
+
+        // 2. 학생의 팀 정보 조회
+        const studentTeam = teamModel.findStudentTeam(user.id);
+        if (!studentTeam) {
+            throw { status: 403, message: '팀에 소속되어 있지 않습니다.' };
+        }
+        const myTeamId = studentTeam.team_id;
+
+        // 3. anger 권한 확인
+        if (!teamModel.hasAngerPermission(myTeamId)) {
+            throw { status: 403, message: '하은이의 분노 권한이 없습니다', code: 'NO_PERMISSION' };
+        }
+
+        // 4. 대상 팀 존재 확인
+        const targetTeam = teamModel.findById(targetTeamId);
+        if (!targetTeam) {
+            throw { status: 404, message: '존재하지 않는 팀입니다', code: 'NON_EXIST_TEAM' };
+        }
+
+        // 5. 크레딧 초기화 실행 및 권한 제거 (트랜잭션)
+        const db = getDatabase();
+        const transaction = db.transaction(() => {
+            teamModel.resetTeamCredit(targetTeamId);
+            teamModel.revokeAngerPermission(myTeamId);
+        });
+        transaction();
+
+        // 6. 최신 팀 정보 조회
+        const updatedMyTeam = teamModel.findById(myTeamId);
+        const updatedTargetTeam = teamModel.findById(targetTeamId);
+
+        return {
+            message: '선택한 팀의 크레딧이 초기화 되었습니다.',
+            myTeam: {
+                teamId: updatedMyTeam.id,
+                credit: updatedMyTeam.team_credit
+            },
+            targetTeam: {
+                teamId: updatedTargetTeam.id,
+                credit: updatedTargetTeam.team_credit
+            }
         };
     }
 };


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #21 

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 선택한 팀의 크레딧을 초기화하는 기능을 만들었습니다

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- `POST /std/select/pull/anger` 엔드포인트 추가
- anger를 뽑았을 때 선택한 팀의 크레딧을 3000으로 초기화
- 자기 팀 선택 시 자신의 팀 초기화 가능
- PERMISSION.ANGER (비트 2, 값 4) 추가, 임시 값 RESET 제거

<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 분노(Anger) 능력 추가: 팀이 다른 팀의 크레딧을 3000으로 리셋할 수 있는 새로운 카드 능력 추가
- 분노 권한 관리 시스템 구현: 특정 팀에 대한 분노 권한 부여, 확인, 취소 기능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->